### PR TITLE
Fixed missing closing quote

### DIFF
--- a/templates/country/place.html
+++ b/templates/country/place.html
@@ -93,7 +93,7 @@
                  <script>
                   $("#submit-{{ dataset.id }}").addClass("disabled");
                   $("#submit-{{ dataset.id }}").attr("data-toggle", "tooltip");
-                  $("#submit-{{ dataset.id }}").attr("title", "{{gettext("Sorry, only one submission can be waiting for review at a time - please come back in a few days to submit new information")}});
+                  $("#submit-{{ dataset.id }}").attr("title", '{{gettext("Sorry, only one submission can be waiting for review at a time - please come back in a few days to submit new information")}}');
                  </script>
               </td>
             </tr>


### PR DESCRIPTION
Was getting a illegal character error on the country/place page. There was a missing quote for a message. Fixed!
