### PR TITLE
Add missing dependencies (used by CLI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
   "license": "MIT",
   "dependencies": {
     "express": "3.x",
-    "execSync": "",
     "nunjucks": "0.1.8",
     "marked": "",
     "csv": "0.3.6",
-    "colors": "",
     "request": "",
     "underscore": "",
     "nconf": "",
@@ -27,6 +25,8 @@
     "moment": "~2.5.1"
   },
   "devDependencies": {
+    "colors": "",
+    "execSync": "",
     "supertest": "",
     "mocha": "",
     "sinon": "",


### PR DESCRIPTION
[execSync](https://www.npmjs.org/package/execSync) and [colors](https://www.npmjs.org/package/colors). (Maybe these are normal ones to have installed globally, but I didn’t have either!)
