### PR TITLE
[#236] Add country rank column to overview page

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -414,6 +414,12 @@ Backend.prototype.getAllEntrysWithInfo = function(db, callback) {
       entry.details_url = '/entry/' + place + '/' + dataset;
     });
     entries.byplace = util.byPlace(db.places, results);
+
+    // take the opportunity to sort places by score
+    db.places = _.sortBy(db.places, function(place) {
+      return entries.byplace[place.id].score * -1;
+    });
+
     var summary = util.getSummaryData(results);
     summary.places = db.places.length;
     entries.summary = summary;

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -39,7 +39,7 @@
   <table class="response-summary table">
 <thead>
   <tr>
-    <th>&nbsp;</th>
+    <th colspan="2">&nbsp;</th>
     {% for dataset in datasets %}
       <th><div><a href="/dataset/{{dataset.id}}">{{ dataset.title|rotate }}</a></div></th>
     {% endfor %}
@@ -49,7 +49,7 @@
 <tbody>
   {% if places.length == 0 %}
   <tr>
-    <td></td>
+    <td colspan="2"></td>
     <td colspan="10">
       <strong><em>{{gettext("The Census Admin needs to add some places to the Places configuration sheet")}}</em></strong>
     </td>
@@ -67,6 +67,7 @@
       #}
       data-score="{{placeScore}}"
       data-area="{{place.name}}">
+      <td>{{ loop.index }}</td>
       <th class="area-name">
         {% if place %}
           <a href="/place/{{ place.id }}">{{place.name}}</a>
@@ -109,7 +110,7 @@
 </tbody>
 <tfoot>
   <tr>
-    <th>&nbsp;</th>
+    <th colspan="2">&nbsp;</th>
     {% for dataset in datasets %}
       <th><div><a href="/dataset/{{dataset.id}}">{{ dataset.title|rotate }}</a></div></th>
     {% endfor %}


### PR DESCRIPTION
This change sorts `OpenDataCensus.data.places` by score in `getAllEntrysWithInfo`. I’m not sure whether it wouldn’t be more robust to sort whenever the overview is requested?

It seems to work this way – I wasn’t able to break the ordering by submitting new data.

One advantage of sorting server-side is it removes the initial FOUP (flash of unranked places!) on the summary page.

Fixes #236.
