### PR TITLE
Show long description on dataset page.

### DIFF
--- a/templates/country/dataset.html
+++ b/templates/country/dataset.html
@@ -17,6 +17,14 @@
         <div class="tab-content">
           <div class="tab-pane active" id="table-overview">
             <div class="table">
+
+{% if dataset.long_description %}
+  <h3>Dataset Description</h3>
+  {{dataset.long_description}}
+{% endif %}
+
+<h3>Dataset Info</h3>
+
 <p>On this page you can see the state of open data for {{ dataset.title }} across all countries for which we have information (displayed down the left hand side). Each icon in the data availability column represents important factors indicating data accessibility or availability - mouse over the icons to see what they are and the colours correspond to yes / no / unsure / no data.</p>
 
 {% if not readonly %}


### PR DESCRIPTION
#### Description

Adds the ability to add an _optional_ `Long_Description` column to the Datasets spreadsheet. Any thing in that column will appear on the individual dataset page.

It renders html tags.
#### Screenshot

![screen shot 2014-05-30 at 11 50 01 am](https://cloud.githubusercontent.com/assets/595778/3134877/48a0ca58-e82b-11e3-97f7-3b117cff0d3a.png)
