### PR TITLE
[#370] Don’t use long_description in templates

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -350,8 +350,8 @@ exports.markupRows = function(datasets) {
 };
 
 exports.markup = function(dataset) {
-  dataset.description = marked(dataset.description || '');
-  dataset.long_description = marked(dataset.long_description || '');
+  // long_description is here for legacy reasons
+  dataset.description = marked(dataset.long_description || dataset.description || '');
   return dataset;
 };
 

--- a/templates/country/dataset.html
+++ b/templates/country/dataset.html
@@ -18,9 +18,9 @@
           <div class="tab-pane active" id="table-overview">
             <div class="table">
 
-{% if dataset.long_description %}
+{% if dataset.description %}
   <h3>Dataset Description</h3>
-  {{dataset.long_description}}
+  {{dataset.description}}
 {% endif %}
 
 <h3>Dataset Info</h3>


### PR DESCRIPTION
Instead, we use (markdownified) `description`. Where a `long_description`
is set we’ll use that instead, but in general it’s deprecated.

Fixes #370.
