### PR TITLE
[#394] Disable travis for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - '0.10'
 script:
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm test'
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm test || false'
 env:
   global:
     # GOOGLE_USER


### PR DESCRIPTION
This is not ideal really… Would be better to just disable travis when
secure environmental variables are not available.
