### PR TITLE
Fix question description popover

### DIFF
--- a/templates/country/entry.html
+++ b/templates/country/entry.html
@@ -42,7 +42,7 @@
       </span>
       {% for qu2 in ynquestions %}
         {% if qu2.id == qu.id %}
-          <a href="javascript:;" data-toggle="popover" data-content="{{ qu2.description|marked }}" data-placement="top">
+          <a href="javascript:;" data-toggle="popover" data-content="{{ qu2.description|marked| replace ('\"', '\'') }}" data-placement="top" data-html="true">
             <i class="icon-info-sign"></i>
           </a>
         {% endif %}


### PR DESCRIPTION
In entry view, question description popover is broken
![2014-11-02 12 59 40](https://cloud.githubusercontent.com/assets/69736/4872511/b7208cf2-61e8-11e4-82a7-6b2a3806b00a.png)
