### PR TITLE
New `survey_year` site setting to specify the active year of survey

### DIFF
--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -132,11 +132,11 @@ var submitPost = function(req, res, data) {
       place: req.body.place,
       dataset: req.body.dataset,
       details: req.body.details,
-      year: req.app.get('year'),
+      year: res.locals.surveyYear,
       submitterId: submitterId
     };
 
-    if (!current || current.year !== req.app.get('year')) {
+    if (!current || current.year !== res.locals.surveyYear) {
       console.log('We are definitely creating a new entry');
 
       objToSave = defaultObjectToSave;
@@ -363,7 +363,7 @@ var pending = function(req, res) {
         entry: entry,
         canReview: canReview,
         reviewClosed: entry.reviewResult ||
-          (entry.year !== req.app.get('year'))
+          (entry.year !== res.locals.surveyYear)
       });
     });
   }).catch(err => console.log(err.stack));

--- a/census/controllers/mixins.js
+++ b/census/controllers/mixins.js
@@ -38,7 +38,10 @@ var setupLocalization = function(req, res, site) {
   res.locals.currentLocale = req.locale;
 };
 
-var requireDomain = function(req, res, next) {
+var requireDomainAssets = function(req, res, next) {
+  /*
+  Add domain specific properties to res.locals.
+  */
   res.locals.domain = req.params.domain;
 
   if (!req.params.domain) {
@@ -80,20 +83,25 @@ var requireDomain = function(req, res, next) {
           res.locals.siteAdmin = req.params.siteAdmin;
 
           req.app.get('models').Site.findById(req.params.domain)
-            .then(function(result) {
-              if (result) {
-                if (result.settings.reviewers) {
-                  result.settings.reviewers = _.each(result.settings.reviewers,
-                    function(e, i, l) {
-                      l[i] = e.trim();
-                    });
-                }
+          .then(function(result) {
+            if (result) {
+              if (result.settings.reviewers) {
+                result.settings.reviewers = _.each(result.settings.reviewers,
+                  function(e, i, l) {
+                    l[i] = e.trim();
+                  });
               }
-              req.params.site = result;
-              res.locals.site = result;
-              setupLocalization(req, res, result);
-              next();
-            });
+            }
+            req.params.site = result;
+            res.locals.site = result;
+            setupLocalization(req, res, result);
+
+            // set survey_year
+            if (_.has(req.params.site, 'settings.survey_year')) {
+              res.locals.surveyYear = req.params.site.settings['survey_year']; // eslint-disable-line dot-notation
+            }
+            next();
+          });
         }
       })
       .catch(function() {
@@ -141,7 +149,8 @@ var requireAvailableYear = function(req, res, next) {
    * If one is not passed, set to current year, and set cascade to true.
    */
   if (typeof req.params.year === 'undefined') {
-    req.params.year = req.app.get('year');
+    // req.params.year = req.app.get('year');
+    req.params.year = res.locals.surveyYear;
     req.params.isYearImplicitlySet = true;
     res.locals.year = req.params.year;
     req.params.cascade = true;
@@ -196,7 +205,7 @@ var requireSiteDomain = function(req, res, next) {
 };
 
 module.exports = {
-  requireDomain: requireDomain,
+  requireDomainAssets: requireDomainAssets,
   requireAuth: requireAuth,
   requireAdmin: requireAdmin,
   requireAvailableYear: requireAvailableYear,

--- a/census/controllers/mixins.js
+++ b/census/controllers/mixins.js
@@ -19,12 +19,12 @@ var setupLocalization = function(req, res, site) {
   var availableLocales = config.get('availableLocales');
   var locales = _.chain(requestedLocales)
     .map(_.trim).filter(function(item) {
-      if (item.length == 0) {
+      if (item.length === 0) {
         return false;
       }
       return availableLocales.indexOf(item) >= 0;
     }).value();
-  if (locales.length == 0) {
+  if (locales.length === 0) {
     locales = config.get('locales');
   }
 
@@ -49,7 +49,6 @@ var requireDomain = function(req, res, next) {
   } else
   if (req.params.domain === req.app.get('authDomain') ||
     req.params.domain === req.app.get('systemDomain')) {
-
     req.params.siteAdmin = [];
     next();
   } else {
@@ -57,7 +56,6 @@ var requireDomain = function(req, res, next) {
 
     query
       .then(function(result) {
-
         if (!result) {
           res.status(404).send({
             status: 'error',
@@ -66,7 +64,7 @@ var requireDomain = function(req, res, next) {
         } else {
           req.session.activeSite = req.params.domain;
           req.params.siteAdmin = result.settings.adminemail;
-          req.params.flags = {'characteristics': false, 'comments': false};
+          req.params.flags = {characteristics: false, comments: false};
           if (result.settings.flags) {
             _.each(result.settings.flags.split(','), function(e, i, l) {
               var feature = e.trim();

--- a/census/controllers/mixins.js
+++ b/census/controllers/mixins.js
@@ -149,7 +149,6 @@ var requireAvailableYear = function(req, res, next) {
    * If one is not passed, set to current year, and set cascade to true.
    */
   if (typeof req.params.year === 'undefined') {
-    // req.params.year = req.app.get('year');
     req.params.year = res.locals.surveyYear;
     req.params.isYearImplicitlySet = true;
     res.locals.year = req.params.year;

--- a/census/controllers/mixins.js
+++ b/census/controllers/mixins.js
@@ -98,7 +98,8 @@ var requireDomainAssets = function(req, res, next) {
 
             // set survey_year
             if (_.has(req.params.site, 'settings.survey_year')) {
-              res.locals.surveyYear = req.params.site.settings['survey_year']; // eslint-disable-line dot-notation
+              res.locals.surveyYear =
+                parseInt(req.params.site.settings['survey_year'], 10); // eslint-disable-line dot-notation
             }
             next();
           });

--- a/census/controllers/pages.js
+++ b/census/controllers/pages.js
@@ -44,7 +44,7 @@ var changes = function(req, res) {
   modelUtils.getData(dataOptions)
     .then(function(data) {
       data.loggedin = req.session.loggedin;
-      data.year = req.app.get('year');
+      data.year = res.locals.surveyYear;
       data.items = _.sortByOrder(data.entries
         .concat(data.pending)
         .concat(data.rejected), 'updatedAt', 'desc');
@@ -101,7 +101,7 @@ var overview = function(req, res) {
       if (!req.params.cascade) {
         data.urlContext += '/YEAR'.replace('YEAR', req.params.year);
       }
-      data.submissionsAllowed = (req.params.year === req.app.get('year'));
+      data.submissionsAllowed = (req.params.year === res.locals.surveyYear);
       data.extraWidth = data.datasets.length > 15;
       data.customText = req.params.site.settings[settingOverviewPage];
       data.missingPlaceText = req.params.site.settings[settingMissingPlace];
@@ -128,7 +128,7 @@ var place = function(req, res) {
       }
       data.loggedin = req.session.loggedin;
       data.year = req.params.year;
-      data.submissionsAllowed = (req.params.year === req.app.get('year'));
+      data.submissionsAllowed = (req.params.year === res.locals.surveyYear);
       data.extraWidth = data.datasets.length > 12;
       data.breadcrumbTitle = data.place.name;
 
@@ -155,7 +155,7 @@ var dataset = function(req, res) {
       }
       data.loggedin = req.session.loggedin;
       data.year = req.params.year;
-      data.submissionsAllowed = req.params.year === req.app.get('year');
+      data.submissionsAllowed = req.params.year === res.locals.surveyYear;
       data.breadcrumbTitle = data.dataset.name;
       return res.render('dataset.html', data);
     }).catch(console.trace.bind(console));
@@ -184,7 +184,7 @@ var entry = function(req, res) {
         data.urlContext += '/YEAR'.replace('YEAR', req.params.year);
       }
       data.year = req.params.year;
-      data.submissionsAllowed = req.params.year === req.app.get('year');
+      data.submissionsAllowed = req.params.year === res.locals.surveyYear;
 
       // TODO calculate relative score of entry
       data.computedRelativeScore = 0;

--- a/census/routes/admin.js
+++ b/census/routes/admin.js
@@ -7,7 +7,7 @@ var utils = require('./utils');
 
 var adminRoutes = function(coreMiddlewares) {
   var router = express.Router();
-  var coreMixins = [mixins.requireDomain, mixins.requireAuth,
+  var coreMixins = [mixins.requireDomainAssets, mixins.requireAuth,
     mixins.requireAdmin];
 
   router.use(coreMiddlewares);

--- a/census/routes/api.js
+++ b/census/routes/api.js
@@ -7,7 +7,7 @@ var utils = require('./utils');
 
 var apiRoutes = function(coreMiddlewares) {
   var router = express.Router();
-  var coreMixins = [mixins.requireDomain, mixins.requireAvailableYear];
+  var coreMixins = [mixins.requireDomainAssets, mixins.requireAvailableYear];
 
   router.use(coreMiddlewares);
 

--- a/census/routes/auth.js
+++ b/census/routes/auth.js
@@ -25,7 +25,7 @@ var authConfig = {
 };
 
 var authRoutes = function(router) {
-  var coreMixins = [mixins.requireAuthDomain, mixins.requireDomain];
+  var coreMixins = [mixins.requireAuthDomain, mixins.requireDomainAssets];
 
   router.get(utils.scoped('/login'), coreMixins, auth.login);
   router.get(utils.scoped('/loggedin'), coreMixins, auth.loggedin);

--- a/census/routes/census.js
+++ b/census/routes/census.js
@@ -5,13 +5,13 @@ var mixins = require('../controllers/mixins');
 var utils = require('./utils');
 
 var censusRoutes = function(router) {
-  var coreMixins = [mixins.requireDomain, mixins.requireAvailableYear,
+  var coreMixins = [mixins.requireDomainAssets, mixins.requireAvailableYear,
     mixins.requireAuth];
 
   router.get(utils.scoped('/submit'), coreMixins, census.submit);
   router.post(utils.scoped('/submit'), coreMixins, census.submit);
   router.get(utils.scoped('/submission/:id'),
-    [mixins.requireDomain, mixins.requireAvailableYear],
+    [mixins.requireDomainAssets, mixins.requireAvailableYear],
     census.review);
   router.post(utils.scoped('/submission/:id'), coreMixins, census.review);
 

--- a/census/routes/i18n.js
+++ b/census/routes/i18n.js
@@ -6,7 +6,7 @@ var utils = require('./utils');
 
 var i18nRoutes = function(coreMiddlewares) {
   var router = express.Router();
-  var coreMixins = [mixins.requireDomain];
+  var coreMixins = [mixins.requireDomainAssets];
 
   router.use(coreMiddlewares);
 

--- a/census/routes/pages.js
+++ b/census/routes/pages.js
@@ -11,7 +11,7 @@ var redirectRoutes = require('./redirects');
 
 var pageRoutes = function(coreMiddlewares) {
   var router = express.Router();
-  var coreMixins = [mixins.requireDomain];
+  var coreMixins = [mixins.requireDomainAssets];
   var byYearMixins = coreMixins.concat(mixins.requireAvailableYear);
   var rootRouteMixins = byYearMixins.concat(mixins.requireSiteDomain);
 

--- a/census/routes/redirects.js
+++ b/census/routes/redirects.js
@@ -5,7 +5,7 @@ var mixins = require('../controllers/mixins');
 var utils = require('./utils');
 
 var redirectRoutes = function(router) {
-  var coreMixins = [mixins.requireDomain];
+  var coreMixins = [mixins.requireDomainAssets];
 
   router.get(utils.scoped('/country'), coreMixins, utils.makeRedirect('/'));
   router.get(utils.scoped('/country/results.json'), coreMixins,

--- a/census/routes/system.js
+++ b/census/routes/system.js
@@ -5,7 +5,7 @@ var mixins = require('../controllers/mixins');
 var utils = require('./utils');
 
 var systemRoutes = function(router) {
-  var coreMixins = [mixins.requireSystemDomain, mixins.requireDomain,
+  var coreMixins = [mixins.requireSystemDomain, mixins.requireDomainAssets,
     mixins.requireAdmin];
 
   router.get(utils.scoped('/control'), coreMixins, system.admin);

--- a/census/routes/utils.js
+++ b/census/routes/utils.js
@@ -138,7 +138,6 @@ var setLocals = function(req, res, next) {
   res.locals.sysAdmin = req.app.get('sysAdmin');
   res.locals.locales = config.get('locales');
   res.locals.currentLocale = req.locale;
-  res.locals.currentYear = req.app.get('year');
   // surveyYear may be overwritten by middleware
   res.locals.surveyYear = req.app.get('year');
 

--- a/census/routes/utils.js
+++ b/census/routes/utils.js
@@ -91,6 +91,10 @@ var setupAuth = function() {
 };
 
 var setLocals = function(req, res, next) {
+  /*
+    Set local response variables for every request.
+  */
+
   var config = req.app.get('config');
 
   if ((config.get('test:testing') === true) &&
@@ -135,6 +139,8 @@ var setLocals = function(req, res, next) {
   res.locals.locales = config.get('locales');
   res.locals.currentLocale = req.locale;
   res.locals.currentYear = req.app.get('year');
+  // surveyYear may be overwritten by middleware
+  res.locals.surveyYear = req.app.get('year');
 
   /* eslint-disable dot-notation */
   res.locals['current_url'] = 'SCHEME://DOMAIN_PATH'

--- a/census/views/includes/dataviews/table_places.html
+++ b/census/views/includes/dataviews/table_places.html
@@ -68,9 +68,9 @@
 
                 {% if is_index != "true" -%}
                   {% if entry -%}
-                    {% if entry.year == currentYear -%}
+                    {% if entry.year == surveyYear -%}
                       {% set badgeClass = 'label-success' %}
-                    {% elif entry.year == (currentYear - 1) %}
+                    {% elif entry.year == (surveyYear - 1) %}
                       {% set badgeClass = 'label-warning' %}
                     {% else %}
                       {% set badgeClass = 'label-important'%}

--- a/fixtures/user.js
+++ b/fixtures/user.js
@@ -36,9 +36,19 @@ var objects = [
     data: {
       id: utils.userIds[3],
       emails: ['email4@example.com'],
-      providers: {'google': 'google4'},
+      providers: {google: 'google4'},
       firstName: 'First4',
       lastName: 'Last4'
+    }
+  },
+  {
+    model: 'User',
+    data: {
+      id: '0e7c393e-71dd-4368-93a9-fcfff59f9fff',
+      emails: ['anonymous@example.com'],
+      providers: {okfn: 'anonymous '},
+      firstName: 'anonymous',
+      lastName: 'anonymous'
     }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-addons-test-utils": "^15.3.0",
     "rewire": "^2.5.2",
     "supertest": "^2.0.0",
+    "timekeeper": "^1.0.0",
     "zombie": "^4.1.0"
   },
   "engines": {

--- a/tests/app.js
+++ b/tests/app.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var assert = require('chai').assert;
 var testUtils = require('./utils');
 var marked = require('marked');
+var tk = require('timekeeper');
 
 var entryFixtures = require('../fixtures/entry');
 var datasetFixtures = require('../fixtures/dataset');
@@ -11,6 +12,16 @@ var userFixtures = require('../fixtures/user');
 var questionSetFixtures = require('../fixtures/questionset');
 
 describe('Basics', function() {
+  before(function() {
+    // Mock date to 2016 for consistent testing
+    tk.freeze(new Date(2016, 11, 30));
+  });
+
+  after(function() {
+    // Reset date mock
+    tk.reset();
+  });
+
   before(testUtils.startApplication);
   after(testUtils.shutdownApplication);
 
@@ -95,8 +106,8 @@ describe('Basics', function() {
           this.browser.visit('/', () => {
             assert.ok(this.browser.success);
             var html = this.browser.html();
-            _.forEach(['custom_css', 'navbar_logo',
-                       'custom_footer', 'support_url'],
+            _.forEach(
+              ['custom_css', 'navbar_logo', 'custom_footer', 'support_url'],
               settingName => {
                 var textToCheck = site.settings[settingName];
                 assert.include(html, textToCheck);

--- a/tests/index.js
+++ b/tests/index.js
@@ -28,7 +28,7 @@ describe('Open Data Census Tests', function() {
   it('counts all users', function() {
     let query = models.User.findAll();
     return query.then(results => {
-      assert.equal(results.length, 4);
+      assert.equal(results.length, 5);
     });
   });
 

--- a/tests/submissions.js
+++ b/tests/submissions.js
@@ -7,8 +7,11 @@ var expressValidator = require('express-validator');
 var chai = require('chai');
 var expect = chai.expect;
 var request = require('supertest');
+var tk = require('timekeeper');
+
 var validateData = require('../census/controllers/utils').validateData;
 var models = require('../census/models');
+var userFixtures = require('../fixtures/user');
 const testUtils = require('./utils');
 
 var validation = function(req, res) {
@@ -353,6 +356,100 @@ describe('#validationData()', function() {
         expect(errors).to.have.property('licenseurl');
         expect(_.size(errors)).to.be.equal(3);
       });
+    });
+  });
+});
+
+describe('submitPost()', function() {
+  before(function() {
+    // Mock date to 2016 for consistent testing
+    tk.freeze(new Date(2016, 11, 30));
+  });
+
+  after(function() {
+    // Reset date mock
+    tk.reset();
+  });
+
+  before(testUtils.startApplication);
+  after(testUtils.shutdownApplication);
+
+  beforeEach(function() {
+    const port = testUtils.app.get('port');
+    this.site = 'http://site1.dev.census.org:' + port + '/';
+    this.app = testUtils.app;
+    const config = this.app.get('config');
+    config.set('test:testing', true);
+    config.set('test:user', {
+      userid: userFixtures[1].data.id,
+      emails: userFixtures[1].data.emails
+    });
+  });
+
+  this.timeout(20000);
+
+  it('should create new entry with calendar year', function() {
+    const siteID = 'site1';
+    return this.app.get('models').Entry.findAll({where: {site: siteID}})
+    .then(data => {
+      const originalEntryLength = data.length;
+      // minimum data necessary to create new entry
+      const newEntryData = {
+        answers: '{}',
+        aboutYouAnswers: '{}',
+        place: 'aplace',
+        dataset: 'adataset'
+      };
+      return request(this.app).post('/submit')
+      .set('Host', 'site1.dev.census.org:5000')
+      .send(newEntryData)
+      .expect(302)
+      .then(res => {
+        return [this.app.get('models').Entry.findAll({where: {site: siteID}}),
+          originalEntryLength];
+      });
+    })
+    .spread((newData, originalEntryLength) => {
+      const newEntry = _.find(newData, {place: 'aplace', dataset: 'adataset'});
+      expect(newEntry.year).to.be.equal(2016);
+      expect(newData.length).to.be.equal(originalEntryLength + 1);
+    });
+  });
+
+  it('should create new entry with survey_year year', function() {
+    const siteID = 'site1';
+    return this.app.get('models').Site.findById(siteID)
+    .then(site => {
+      // Set site1 `survey_year` to 2014.
+      let settings = _.assign(site.settings, {survey_year: '2014'});
+      return site.update({settings: settings});
+    })
+    .then(site => {
+      return this.app.get('models').Entry.findAll({where: {site: siteID}});
+    })
+    .then(entries => {
+      const originalEntryLength = entries.length;
+      // minimum data necessary to create new entry
+      const newEntryData = {
+        answers: '{}',
+        aboutYouAnswers: '{}',
+        place: 'anotherplace',
+        dataset: 'adataset'
+      };
+      return request(this.app).post('/submit')
+      .set('Host', 'site1.dev.census.org:5000')
+      .send(newEntryData)
+      .expect(302)
+      .then(res => {
+        return [this.app.get('models').Entry.findAll({where: {site: siteID}}),
+          originalEntryLength];
+      });
+    })
+    .spread((newData, originalEntryLength) => {
+      const newEntry = _.find(newData,
+        {place: 'anotherplace', dataset: 'adataset'});
+      expect(newEntry.year).to.be.equal(2014);
+      expect(newData.length).to.be.equal(originalEntryLength + 1);
     });
   });
 });


### PR DESCRIPTION
This part fulfils #869.

By default a site will be open for submissions and review for the current calendar year. In a new year, the survey site will close for the previous year and begin accepting entries for the new year.

This PR adds some control for site admins to allow the survey year to be specified as a site property in the CMS: `survey_year`. If specified, this will be used as the 'year of interest' for the survey. Entries and reviews will continue to be open for that specified year, rather than whatever the current calendar year is.