### PR TITLE
API download for pending entries

### DIFF
--- a/census/routes/api.js
+++ b/census/routes/api.js
@@ -17,6 +17,10 @@ var apiRoutes = function(coreMiddlewares) {
     api.entries);
   router.get(utils.scoped('/entries/:year.:format'), coreMixins, api.entries);
   router.get(utils.scoped('/entries.:format'), coreMixins, api.entries);
+  router.get(utils.scoped('/pendingentries/:year.:format'),
+    coreMixins, api.pendingEntries);
+  router.get(utils.scoped('/pendingentries.:format'),
+    coreMixins, api.pendingEntries);
   router.get(utils.scoped('/datasets/:report/:year.:strategy.:format'),
     coreMixins, api.datasets);
   router.get(utils.scoped('/datasets/:report/:year.:format'),


### PR DESCRIPTION
Adds a `pendingEntries` endpoint. Very similar to the existing `entries` endpoint.

Moves the results mapping to a helper function for use by both `entries` and `pendingEntries`.