### PR TITLE
Load Index settings from CMS

### DIFF
--- a/census/controllers/admin.js
+++ b/census/controllers/admin.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _ = require('lodash');
-var loaders = require('../loaders');
-var modelUtils = require('../models').utils;
-var utils = require('./utils');
+const _ = require('lodash');
+const loaders = require('../loaders');
+const modelUtils = require('../models').utils;
+const utils = require('./utils');
 
-var promisedLoad = function(req, res, options) {
+let promisedLoad = function(req, res, options) {
   return loaders.loadTranslatedData(options, req.app.get('models'))
     .then(function() {
       res.send({status: 'ok', message: 'ok'});
@@ -15,8 +15,8 @@ var promisedLoad = function(req, res, options) {
     });
 };
 
-var dashboard = function(req, res) {
-  var dataOptions = _.merge(modelUtils.getDataOptions(req), {
+let dashboard = function(req, res) {
+  const dataOptions = _.merge(modelUtils.getDataOptions(req), {
     with: {Entry: false}
   });
   modelUtils.getData(dataOptions)
@@ -25,7 +25,7 @@ var dashboard = function(req, res) {
     }).catch(console.trace.bind(console));
 };
 
-var loadConfig = function(req, res) {
+let loadConfig = function(req, res) {
   return loaders.loadConfig(req.params.domain, req.app.get('models'))
     .then(function() {
       res.send({status: 'ok', message: 'ok'});
@@ -35,7 +35,7 @@ var loadConfig = function(req, res) {
     });
 };
 
-var loadPlaces = function(req, res) {
+let loadPlaces = function(req, res) {
   return promisedLoad(req, res, {
     mapper: utils.placeMapper,
     Model: req.app.get('models').Place,
@@ -44,7 +44,7 @@ var loadPlaces = function(req, res) {
   });
 };
 
-var loadDatasets = function(req, res) {
+let loadDatasets = function(req, res) {
   return promisedLoad(req, res, {
     mapper: utils.datasetMapper,
     Model: req.app.get('models').Dataset,
@@ -53,7 +53,7 @@ var loadDatasets = function(req, res) {
   });
 };
 
-var loadQuestionSets = function(req, res) {
+let loadQuestionSets = function(req, res) {
   /*
   For each Dataset in the site, load the associated QuestionSet.
   */

--- a/census/loaders/index.js
+++ b/census/loaders/index.js
@@ -9,14 +9,14 @@ const marked = require('marked');
 const crypto = require('crypto');
 const util = require('util');
 
-var loadConfig = function(siteId, models) {
+let loadConfig = function(siteId, models) {
   return models.Registry.findById(siteId)
   .then(registry => {
     return utils.spreadsheetParse(registry.settings.configurl);
   })
   .then(config => {
-    var settings = {};
-    var raw = _.object(_.zip(_.pluck(config, 'key'), _.pluck(config, 'value')));
+    let settings = {};
+    const raw = _.object(_.zip(_.pluck(config, 'key'), _.pluck(config, 'value')));
     _.each(raw, function(v, k) {
       if (v && _.trim(v.toLowerCase()) === 'true') {
         settings[k] = true;
@@ -178,7 +178,7 @@ let _createQuestionSetForDatasets = function(datasets,
   });
 };
 
-var loadQuestionSets = function(siteId, models, transaction) {
+let loadQuestionSets = function(siteId, models, transaction) {
   return models.sequelize.transaction(t => {
     if (transaction !== undefined) {
       t = transaction;
@@ -217,8 +217,8 @@ var loadQuestionSets = function(siteId, models, transaction) {
   });
 };
 
-var loadRegistry = function(models) {
-  var registryUrl = config.get('registryUrl') || false;
+let loadRegistry = function(models) {
+  let registryUrl = config.get('registryUrl') || false;
 
   return utils.spreadsheetParse(registryUrl)
   .then(registry => {
@@ -261,7 +261,7 @@ var loadRegistry = function(models) {
   url defined at setting 'datasets'. Create instances of the Model 'Dataset'
   with the retrieved data, using the optional mapper function.
   */
-var loadData = function(options, models) {
+let loadData = function(options, models) {
   return models.sequelize.transaction(function(t) {
     return models.Site.findById(options.site, {transaction: t})
     .then(site => {

--- a/census/migrations/20160909155202-data-migration-add-dummy-questionsetid.js
+++ b/census/migrations/20160909155202-data-migration-add-dummy-questionsetid.js
@@ -5,14 +5,33 @@ const models = require('../models');
 
 module.exports = {
   up: function (queryInterface, Sequelize) {
-    return models.Site.findAll()
+    // Use this version of the Site model, which was current at time of
+    // migration.
+    let Site = queryInterface.sequelize.define('Site', {
+      id: {
+        type: Sequelize.STRING,
+        primaryKey: true,
+        allowNull: false
+      },
+      settings: {
+        type: Sequelize.JSONB,
+        allowNull: false
+      }
+    }, {
+      tableName: 'site'
+    });
+
+    return Site.findAll()
     .then(sites => {
       // For each site
       return Promise.each(sites, site => {
         // Create a QuestionSet
-        return models.QuestionSet.create({id: 'dummy-qs-' + site.id,
-                                   site: site.id,
-                                   qsSchema: []})
+        return models.QuestionSet.create(
+          {
+            id: 'dummy-qs-' + site.id,
+            site: site.id,
+            qsSchema: []
+          })
         .then(qs => {
           // And associates all Questions for the site
           return models.Question.findAll({where: {site: site.id}})

--- a/census/migrations/20170127121853-add-site-indexconfig.js
+++ b/census/migrations/20170127121853-add-site-indexconfig.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.addColumn('site', 'indexSettings',
+      {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: 'Index configuration settings.'
+      });
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.removeColumn('site', 'indexSettings');
+  }
+};
+

--- a/census/models/site.js
+++ b/census/models/site.js
@@ -13,6 +13,10 @@ module.exports = function(sequelize, DataTypes) {
     settings: {
       type: DataTypes.JSONB,
       allowNull: false
+    },
+    indexSettings: {
+      type: DataTypes.JSONB,
+      allowNull: true
     }
   }, {
     tableName: 'site'

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -63,10 +63,14 @@ describe('Admin page', function () {
       let jsonData = JSON.parse(html);
       assert.equal(jsonData.status, 'ok');
       assert.equal(jsonData.message, 'ok');
-      return this.app.get('models').Site.findById(siteID).then(function (data) {
+      return this.app.get('models').Site.findById(siteID)
+      .then(data => {
         assert.isNotNull(data);
         assert.notEqual(data.places, '');
-        assert.notEqual(data.places, '');
+        assert.equal(typeof data.settings, 'object');
+        assert.equal(typeof data.indexSettings, 'object');
+        assert.equal(data.settings.title, 'Open Data Census: Test Site 3');
+        assert.equal(data.indexSettings.title, 'Open Data Index: Test Site 3');
         assert.notEqual(data.datasets, '');
         assert.notEqual(data.questions, '');
       });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -54,24 +54,19 @@ exports.shutdownApplication = function(done) {
 
 exports.setupFixtures = function(done) {
   models.sequelize.getQueryInterface().dropAllTables()
-    .then(function() {
-
-      models.umzug.up().then(function() {
-
-        return Promise.each(data, function(obj) {
-          return models[obj.model].create(obj.data)
-            .then(function() {})
-            .catch(console.trace.bind(console));
-        })
-          .then(function() {
-            // console.log('fixtures loaded');
-            done();
-          })
-          .catch(console.trace.bind(console));
-
-      });
-
+  .then(() => {
+    return models.umzug.up();
+  })
+  .then(migrations => {
+    return Promise.each(data, obj => {
+      return models[obj.model].create(obj.data);
     });
+  })
+  .then(() => {
+    // console.log('fixtures loaded');
+    done();
+  })
+  .catch(console.trace.bind(console));
 };
 
 exports.dropFixtures = function(done) {


### PR DESCRIPTION
This PR loads settings from the spreadsheet CMS for use by the Index static site. The URL for the settings spreadsheet is defined by an `index_config` key on the site settings. Index settings will be loaded as part of the general site configuration loading.