### PR TITLE
Output answer values to Survey entry page

### DIFF
--- a/census/views/entry.html
+++ b/census/views/entry.html
@@ -81,6 +81,51 @@
     {%- endfor %}
     </ul>
 
+    {% if not is_index %}
+      {% set answers = entry.getSimpleAnswersForQuestions(questions) %}
+      <h3>{{ gettext("All answers") }}</h3>
+      <table class="table table-striped yntable">
+        <tbody>
+          <tr>
+            <th>{{ gettext("Question")}}</th>
+            <th>{{ gettext("Answer") }}</th>
+            <th>{{ gettext("Comment")}}</th>
+          </tr>
+        {% for answer in answers %}
+          {% if answer.value %}
+          {% set question = questions|find({id: answer.id}) %}
+          {% set answerValue = '' %}
+
+          {% if question.type == 'source' %}
+          {# Special treatment for 'source' question type. #}
+            {% for source in answer.value %}
+              {% set answerValue = answerValue + source.urlValue + ' - ' + source.descValue %}
+              {% if not loop.last %}
+                {% set answerValue = answerValue + ', ' %}
+              {% endif %}
+            {% endfor %}
+            {% set answerValue = answerValue|marked %}
+          {% elif question.type == 'multiple' %}
+          {# Special treatment for 'multiple' question type. #}
+            {% set answerValue = answer.value|join(', ') %}
+          {% elif question.id == 'licence_url' %}
+          {# Special treatment for 'licence_url' question id. #}
+            {% set answerValue = answer.value|marked %}
+          {% else %}
+            {% set answerValue = answer.value %}
+          {% endif %}
+
+          <tr>
+            <td>{{question.questionshort or answer.id}}</td>
+            <td>{{answerValue}}</td>
+            <td>{{answer.commentValue}}</td>
+          </tr>
+          {% endif %}
+        {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+
     {% if entry.details %}
     <div class="place-details">
       <h4><strong>{{ gettext("Details") }}</strong></h4>


### PR DESCRIPTION
This PR outputs a table of Question/Answer/Comment rows for each answer provided for an entry. This should help enable reviewers to assess an already-published entry. There is special handling for some question types to enable linking, and better handle list rendering.

<img width="1178" alt="screen shot 2017-02-17 at 13 59 01" src="https://cloud.githubusercontent.com/assets/3993/23067917/47bba754-f519-11e6-9bb8-5b0e9371eff1.png">

Fixes #931.