### PR TITLE
Check INDEX_DOMAIN_SUFFIX exists before generation

### DIFF
--- a/index/generate.js
+++ b/index/generate.js
@@ -157,6 +157,12 @@ if (options.deploy &&
 // development, staging and production.
 const indexDomainSuffix = (process.env.INDEX_DOMAIN_SUFFIX) ?
   `-${process.env.INDEX_DOMAIN_SUFFIX}` : '';
+// If this is not the production instance, there MUST be an
+// INDEX_DOMAIN_SUFFIX set in the env.
+if (process.env.NODE_ENV !== 'production' && indexDomainSuffix === '') {
+  console.error('NODE_ENV is not \'production\', so INDEX_DOMAIN_SUFFIX must be set to prevent overwriting production sites.');
+  process.exit(1);
+}
 const isGodi = (options.site === 'global' || options.site === 'global-test');
 const domain = options.site;
 const year = options.year;

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "generate_index_dev": "DEBUG=metalsmith-godi-*,metalsmith-timer INDEX_DOMAIN_SUFFIX=dev node index/generate.js",
     "migrate_users": "node scripts/users.js",
     "start": "node server.js",
+    "start_dev": "INDEX_DOMAIN_SUFFIX=dev nodemon start -e js,jsx,html,json --ignore index/",
     "debug": "node-debug debug-server.js --no-preload --hidden='node_modules'",
     "test": "NODE_ENV=test ./node_modules/istanbul/lib/cli.js cover -x '**/census/migrations/**' -x '**/scripts/**' ./node_modules/mocha/bin/_mocha -- --compilers js:babel-core/register -R spec tests/ --harmony",
     "lint": "eslint census/**/*.js census/**/*.jsx --ignore-pattern '**/census/migrations/**' --ignore-pattern '**/census/locale/**' --quiet || exit 0",


### PR DESCRIPTION
`INDEX_DOMAIN_SUFFIX` env var is used to build the bucket name when generating a static Index site. The idea is that dev and staging instances will use the suffix to build to their own buckets, and not overwrite production buckets. However, if the developer forgets to add the env var, it's very easy to generate a site that overwrites production instances from development and staging environments. 

This PR checks that INDEX_DOMAIN_SUFFIX is available if attempting to generate a static Index site when NODE_ENV isn't 'production'. This prevents generation to the production buckets for any instance that isn't 'production'. 

Fixes #949.