### PR TITLE
Add question popover explanations

### DIFF
--- a/census/views/entry.html
+++ b/census/views/entry.html
@@ -81,7 +81,7 @@
     </div>
     {% endif %}
 
-    <h3>{{ gettext("What data is available?") }}</h3>
+    <h3>{{ gettext("How open is the data?") }}</h3>
     <ul class="availability-single">
     {% for question in questions -%}
       {% if question.score -%}

--- a/census/views/entry.html
+++ b/census/views/entry.html
@@ -1,5 +1,7 @@
 {% extends "page.html" %}
 
+{% import "macros/popovers.html" as popovers %}
+
 {% block title %}{{format("Entry for %(place)s / %(title)s", { place: place.name, title: dataset.name}) }}{% endblock %}
 
 {% block breadcrumb %}
@@ -87,7 +89,7 @@
       {% if question.score -%}
         {% set answer = entry.getAnswerValueForQuestion(question) %}
         {% set pass = 'yes' if question.pass(answer) else 'no' %}
-        <li class="{{ pass }}" title="{{ question.question }}">
+        <li class="{{ pass }}" title="{{ question.question }}" data-toggle="popover" data-content="{{ popovers.popover_slice_content(question.description)|escape }}" data-placement="right">
           <i class="fa fa-{{ question.icon }}"></i>&nbsp;{% if pass == 'yes' %}It's {% elif pass == 'no' %}It's not {% endif %}{{ question.questionshort|lower }}
         </li>
       {%- endif %}
@@ -198,6 +200,6 @@
 </section>
 {% endif %}
 
-<script src="{{page.root}}/src/common.js?{{currentTime}}"></script>
+<div id="popover" class="popover fade bottom in" role="tooltip"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>
 
 {% endblock %}

--- a/census/views/includes/dataviews/table_slice_dataset.html
+++ b/census/views/includes/dataviews/table_slice_dataset.html
@@ -1,11 +1,14 @@
+{% import "macros/popovers.html" as popovers %}
+
+{% if is_index %}
+  {% set tableId = 'slice-table-index' %}
+  {% set sortby = 'rank' %}
+{% else %}
+  {% set tableId = 'slice-table' %}
+  {% set sortby = 'name' %}
+{% endif %}
+
 <div class="table-responsive">
-    {% if is_index %}
-      {% set tableId = 'slice-table-index' %}
-      {% set sortby = 'rank' %}
-    {% else %}
-      {% set tableId = 'slice-table' %}
-      {% set sortby = 'name' %}
-    {% endif %}
     <table id="{{ tableId }}" class="table slice-table data-table table-header-stuck">
         {% if is_index %}
         <colgroup>
@@ -56,7 +59,7 @@
                       {% set answer = entry.getAnswerValueForQuestion(question) %}
                       {% set pass = 'yes' if question.pass(answer) else 'no' %}
                     {% endif %}
-                    <li class="{{ pass }}" title="{% if pass == 'yes' %}It's {% elif pass == 'no' %}It's not {% endif %}{{ question.questionshort|lower }}"><i class="fa fa-{{ question.icon }}"></i>&nbsp;</li>
+                    <li class="{{ pass }}" title="{{ question.question }}" data-toggle="popover" data-content="{{ popovers.popover_slice_content(question.description)|escape }}"><i class="fa fa-{{ question.icon }}"></i>&nbsp;</li>
                   {% endfor %}
                 </ul>
               </td>
@@ -163,3 +166,4 @@
         </tbody>
     </table>
 </div>
+<div id="popover" class="popover fade bottom in" role="tooltip"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>

--- a/census/views/includes/dataviews/table_slice_place.html
+++ b/census/views/includes/dataviews/table_slice_place.html
@@ -1,3 +1,5 @@
+{% import "macros/popovers.html" as popovers %}
+
 {% if is_index and not place and data -%}
   {% set place = data %}
 {%- endif %}
@@ -62,7 +64,7 @@
                       {% set answer = entry.getAnswerValueForQuestion(question) %}
                       {% set pass = 'yes' if question.pass(answer) else 'no' %}
                     {% endif %}
-                    <li class="{{ pass }}" title="{% if pass == 'yes' %}It's {% elif pass == 'no' %}It's not {% endif %}{{ question.questionshort|lower }}"><i class="fa fa-{{ question.icon }}"></i>&nbsp;</li>
+                    <li class="{{ pass }}" title="{% if pass == 'yes' %}It's {% elif pass == 'no' %}It's not {% endif %}{{ question.questionshort|lower }}" title="{{ question.question }}" data-toggle="popover" data-content="{{ popovers.popover_slice_content(question.description)|escape }}"><i class="fa fa-{{ question.icon }}"></i>&nbsp;</li>
                   {% endfor %}
                 </ul>
               </td>
@@ -170,3 +172,4 @@
         </tbody>
     </table>
 </div>
+<div id="popover" class="popover fade bottom in" role="tooltip"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>

--- a/census/views/includes/dataviews/table_slice_place.html
+++ b/census/views/includes/dataviews/table_slice_place.html
@@ -64,7 +64,7 @@
                       {% set answer = entry.getAnswerValueForQuestion(question) %}
                       {% set pass = 'yes' if question.pass(answer) else 'no' %}
                     {% endif %}
-                    <li class="{{ pass }}" title="{% if pass == 'yes' %}It's {% elif pass == 'no' %}It's not {% endif %}{{ question.questionshort|lower }}" title="{{ question.question }}" data-toggle="popover" data-content="{{ popovers.popover_slice_content(question.description)|escape }}"><i class="fa fa-{{ question.icon }}"></i>&nbsp;</li>
+                    <li class="{{ pass }}" title="{{ question.question }}" data-toggle="popover" data-content="{{ popovers.popover_slice_content(question.description)|escape }}"><i class="fa fa-{{ question.icon }}"></i>&nbsp;</li>
                   {% endfor %}
                 </ul>
               </td>

--- a/census/views/macros/popovers.html
+++ b/census/views/macros/popovers.html
@@ -49,3 +49,7 @@
 
 {%- endif %}
 {%- endmacro %}
+
+{% macro popover_slice_content(description) -%}
+{{ description|marked }}
+{%- endmacro %}


### PR DESCRIPTION
Question explanations in popovers triggered by clicking the Question icon, added to entry, place, and dataset pages.

Connected to #843.