### PR TITLE
Add forum link to entry detail pages.

### DIFF
--- a/census/views/entry.html
+++ b/census/views/entry.html
@@ -191,6 +191,20 @@
     </div>
   </div>
 </section>
+
+  {% if discussionUrl %}
+  <section>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h3>{{ gettext("Discuss this entry") }}</h3>
+          <p>Do you want to discuss this entry? Start a <a target="_blank" href="{{ discussionUrl }}">new topic</a> on the forum!</p>
+        </div>
+      </div>
+    </div>
+  </section>
+  {% endif %}
+
 {% endif %}
 
 {% if not is_index %}

--- a/index/generate.js
+++ b/index/generate.js
@@ -188,11 +188,11 @@ Metalsmith(__dirname)
   .clean(options.clean)
   .use(godiGetData({domain: domain, year: year})) // Populate metadata with data from Survey
   .use(jsonToFiles({use_metadata: true}))
-  .use(godiDataFiles()) // Add file metadata to each entry file populated by json-to-files
+  .use(paths({property: 'paths', directoryIndex: 'index.html'}))
   .use(godiIndexSettings({domain: domain})) // Add data from Index settings.
+  .use(godiDataFiles()) // Add file metadata to each entry file populated by json-to-files
   .use(markdown())
   .use(permalinks())
-  .use(paths({property: 'paths', directoryIndex: 'index.html'}))
   .use(layouts({
     engine: 'nunjucks',
     rename: true,

--- a/index/metalsmith-godi-indexsettings.js
+++ b/index/metalsmith-godi-indexsettings.js
@@ -55,6 +55,12 @@ function plugin(options) {
       if (indexSettings.title) {
         metadata.site_title = indexSettings.title;
       }
+
+      // Add entry_discussion_url to metadata
+      if (indexSettings.entry_discussion_url) {
+        metadata.discussionUrl = indexSettings.entry_discussion_url;
+      }
+
       done();
     })
     .catch(err => done(err));

--- a/index/metalsmith-godi-updatedatafiles.js
+++ b/index/metalsmith-godi-updatedatafiles.js
@@ -4,6 +4,9 @@ const _ = require('lodash');
 
 const debug = require('debug')('metalsmith-godi-updatedatafiles');
 
+const buildDiscussionUrl =
+  require('../census/controllers/utils.js').buildDiscussionUrl;
+
 module.exports = plugin;
 
 /**
@@ -32,6 +35,15 @@ function plugin(options) {
           file.entry = file.data;
           file.place = _.find(metadata.places, {id: file.entry.place});
           file.dataset = _.find(metadata.datasets, {id: file.entry.dataset});
+          // Add discussion_url to entry data
+          if (metadata.discussionUrl) {
+            file.discussionUrl = buildDiscussionUrl(metadata.discussionUrl,
+                                                    metadata.gettext,
+                                                    `${metadata.site_url}${file.paths.href}`,
+                                                    file.dataset.id,
+                                                    file.place.id);
+          }
+
           delete file.data;
         }
 


### PR DESCRIPTION
Reuses much of the code used for the submission discussion link on the Survey entry form page.

Connected to #843. Closes #980.