### PR TITLE
Create download page and data archive

### DIFF
--- a/census/views/base.html
+++ b/census/views/base.html
@@ -70,6 +70,7 @@
             {% if is_index %}
               <li><a href="/place/">{{ gettext("Places") }}</a></li>
               <li><a href="/dataset/">{{ gettext("Datasets") }}</a></li>
+              <li><a href="/download/">{{ gettext("Download") }}</a></li>
               {% if 'insights' in ancillary_pages %}
                 <li><a href="/insights/">{{ gettext("Insights") }}</a></li>
               {% endif %}
@@ -152,12 +153,14 @@
         </div>
         {% endif %}
         <div class="footer-secondary">
+          {% if not is_index %}
           <p class="pull-right">
             <strong>{{ gettext("Download") }}:</strong> <a href="/api/entries.cascade.csv">{{ gettext("Current (CSV)") }}</a> |
             <a href="/api/entries.csv">{{ gettext("All (CSV)") }}</a> |
             <a href="/api/entries.cascade.json">{{ gettext("Current (JSON)") }}</a> |
             <a href="/api/entries.json">{{ gettext("All (JSON)") }}</a>
           </p>
+          {% endif %}
           <p>
             <a href="http://opendatacommons.org/licenses/pddl/1.0">{{ gettext("Data License (Public Domain)") }}</a>. <a href="https://github.com/okfn/opendatasurvey/">{{ gettext("Source code") }}</a>.
           </p>

--- a/census/views/download.html
+++ b/census/views/download.html
@@ -11,7 +11,7 @@
       <h3>{{ gettext('Archive') }}</h3>
       <p>{{ gettext('All data as an archive file.') }}</p>
       <p>
-        <a class="btn btn-primary btn-lg {% if ODI.forms.download %}download-action{% endif %}" href="/static/downloads/opendataindex_data_{{ TIMESTAMP }}.tar.gz" title="{{ gettext('The whole Index displayed in an easy-to-read table.') }}">
+        <a class="btn btn-primary btn-lg {% if ODI.forms.download %}download-action{% endif %}" href="/download/opendataindex_data.zip" title="{{ gettext('The whole Index displayed in an easy-to-read table.') }}">
           {{ gettext('Download all data') }}
         </a>
       </p>

--- a/census/views/download.html
+++ b/census/views/download.html
@@ -4,7 +4,7 @@
 <div class="container">
 <section class="row">
     <div class="col-md-12">
-    {{ page.content }}
+    {{ contents }}
     </div>
   <div class="col-md-4">
     <div class="">

--- a/census/views/download.html
+++ b/census/views/download.html
@@ -1,0 +1,126 @@
+{% extends 'page.html' %}
+
+{% block content %}
+<div class="container">
+<section class="row">
+    <div class="col-md-12">
+    {{ page.content }}
+    </div>
+  <div class="col-md-4">
+    <div class="">
+      <h3>{{ gettext('Archive') }}</h3>
+      <p>{{ gettext('All data as an archive file.') }}</p>
+      <p>
+        <a class="btn btn-primary btn-lg {% if ODI.forms.download %}download-action{% endif %}" href="/static/downloads/opendataindex_data_{{ TIMESTAMP }}.tar.gz" title="{{ gettext('The whole Index displayed in an easy-to-read table.') }}">
+          {{ gettext('Download all data') }}
+        </a>
+      </p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="">
+      <h3>{{ gettext('CSV') }}</h3>
+      <p>{{ gettext('Data in CSV format.') }}</p>
+      <p>
+        <div class="btn-group">
+          <button type="button" class="btn btn-primary btn-lg dropdown-toggle" data-toggle="dropdown">
+            {{ gettext('Download CSV') }} <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu">
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/entries.csv">
+                {{ gettext('Entries') }}
+              </a>
+            </li>
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/datasets.csv">
+                {{ gettext('Datasets') }}
+              </a>
+            </li>
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/places.csv">
+                {{ gettext('Places') }}
+              </a>
+            </li>
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/questions.csv">
+                {{ gettext('Questions') }}
+              </a>
+            </li>
+          </ul>
+        </div>
+      </p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="">
+      <h3>{{ gettext('JSON') }}</h3>
+      <p>{{ gettext('Data in JSON format.') }}</p>
+      <p>
+        <div class="btn-group">
+          <button type="button" class="btn btn-primary btn-lg dropdown-toggle" data-toggle="dropdown">
+            {{ gettext('Download JSON') }} <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu">
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/entries.json">
+                {{ gettext('Entries') }}
+              </a>
+            </li>
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/datasets.json">
+                {{ gettext('Datasets') }}
+              </a>
+            </li>
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/places.json">
+                {{ gettext('Places') }}
+              </a>
+            </li>
+            <li>
+              <a class="{% if ODI.forms.download %}download-action{% endif %}" href="/api/questions.json">
+                {{ gettext('Questions') }}
+              </a>
+            </li>
+          </ul>
+        </div>
+      </p>
+    </div>
+  </div>
+</section>
+</div>
+
+{% if ODI.forms.download %}
+<section>
+    <div class="row">
+        <div class="col-md-3"></div>
+        <div class="col-md-6">
+            <div class="tell-me-embedded">
+                <iframe src="{{ ODI.forms.download.url }}" width="{{ ODI.forms.download.width }}" height="{{ ODI.forms.download.height }}" frameborder="0" marginheight="0" marginwidth="0">{{ gettext('Loading') }}...</iframe>
+            </div>
+        </div>
+        <div class="col-md-3"></div>
+    </div>
+</section>
+{% endif %}
+
+{% if ODI.forms.download %}
+<div class="modal" id="tell-us" tabindex="-1" role="dialog" aria-labelledby="tell-us-label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">{{ gettext('Close') }}</span></button>
+        <h4 class="modal-title" id="tell-us-label">{{ gettext('Your download has begun') }}</h4>
+      </div>
+      <div class="modal-body">
+        <iframe src="{{ ODI.forms.download.url }}" width="{{ ODI.forms.download.width }}" height="{{ ODI.forms.download.height }}" frameborder="0" marginheight="0" marginwidth="0">{{ gettext('Loading') }}...</iframe>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">{{ gettext('Close') }}</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+{% endblock content %}

--- a/index/src/download/index.md
+++ b/index/src/download/index.md
@@ -1,5 +1,7 @@
 ---
 title: Download
 layout: download.html
-breadcrumbTitle: Downloads
+breadcrumbTitle: Download
 ---
+
+The data of the Index is available for use under a [public domain data license](http://opendatacommons.org/licenses/pddl/1.0/). We provide the data as a single archive, and as individual files in CSV and JSON formats.

--- a/index/src/download/index.md
+++ b/index/src/download/index.md
@@ -1,0 +1,5 @@
+---
+title: Download
+layout: download.html
+breadcrumbTitle: Downloads
+---

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "i18n-abide": "^0.0.25",
     "jquery": "^3.1.0",
     "jsonexport": "^1.5.2",
+    "jszip": "^3.1.3",
     "linkifyjs": "^2.0.0-beta.4",
     "lodash": "^3.10.0",
     "marked": "^0.3.3",


### PR DESCRIPTION
This PR adds the /download page to the static site build of the Index site. It also builds a zip archive of the csv/json data retrieved from the Survey site, making it available for download.

Closes #969.