### PR TITLE
Shorten long urls for display on entry pages

### DIFF
--- a/census/filters.js
+++ b/census/filters.js
@@ -3,7 +3,6 @@
 var _ = require('lodash');
 var moment = require('moment');
 var markedlib = require('marked');
-var linkifyStr = require('linkifyjs/string');
 
 markedlib.setOptions({
   gfm: true,
@@ -16,10 +15,6 @@ var find = function(list, args) {
 
 var where = function(list, args) {
   return _.where(list, args);
-};
-
-var urlize = function(str) {
-  return linkifyStr(str);
 };
 
 var wordwrap = function(str, width, brk, cut) {
@@ -101,7 +96,6 @@ var simpledelta = function(str) {
 module.exports = {
   find: find,
   where: where,
-  urlize: urlize,
   wordwrap: wordwrap,
   truncate: truncate,
   rotate: rotate,

--- a/census/filters.js
+++ b/census/filters.js
@@ -33,17 +33,6 @@ var wordwrap = function(str, width, brk, cut) {
   return str.match(RegExp(regex, 'g')).join(brk);
 };
 
-var truncate = function(str, width) {
-  width = width || 100;
-  if (!str) {
-    return str;
-  }
-  if (str.length <= width) {
-    return str;
-  }
-  return str.substr(0, width - 1) + '...';
-};
-
 // Why? Rotated Heading Cells are hard.
 // every token after "halfway" joined with &nbsp;
 var rotate = function(str) {
@@ -97,7 +86,6 @@ module.exports = {
   find: find,
   where: where,
   wordwrap: wordwrap,
-  truncate: truncate,
   rotate: rotate,
   dateformat: dateformat,
   marked: marked,

--- a/census/views/entry.html
+++ b/census/views/entry.html
@@ -118,7 +118,7 @@
       {% if licence_answer %}
       <div class="col-md-6">
         <h4>{{ gettext("Data licence") }}</h4>
-        <p>{{ licence_answer|urlize }}</p>
+        <p>{{ licence_answer|urlize(55, true)|safe }}</p>
       </div>
       {% endif %}
       {% if source_answer %}
@@ -128,7 +128,7 @@
         <ul>
         {% for source in source_answer %}
           {% if source.urlValue %}
-            {% set sourceValue = source.urlValue %}
+            {% set sourceValue = source.urlValue|urlize(55, true)|safe %}
             {% if source.descValue %}
               {% set sourceValue = sourceValue + ' - ' + source.descValue %}
             {% endif %}
@@ -137,7 +137,7 @@
           {% endif %}
         {% endfor %}
         </ul>
-        <p>{{ answerValue|marked }}</p>
+        <p>{{ answerValue }}</p>
       </div>
       {% endif %}
     </div>
@@ -161,7 +161,7 @@
           {% if question.type == 'source' %}
           {# Special treatment for 'source' question type. #}
             {% for source in answer.value %}
-              {% set answerValue = answerValue + source.urlValue + ' - ' + source.descValue %}
+              {% set answerValue = answerValue + source.urlValue|urlize(55, true)|safe + ' - ' + source.descValue %}
               {% if not loop.last %}
                 {% set answerValue = answerValue + ', ' %}
               {% endif %}
@@ -172,7 +172,7 @@
             {% set answerValue = answer.value|join(', ') %}
           {% elif question.id == 'licence_url' %}
           {# Special treatment for 'licence_url' question id. #}
-            {% set answerValue = answer.value|urlize %}
+            {% set answerValue = answer.value|urlize(55, true)|safe %}
           {% else %}
             {% set answerValue = answer.value %}
           {% endif %}


### PR DESCRIPTION
Source and Licence URL values can sometimes be very long (e.g. http://global.survey.okfn.org/entry/sk/statistics). This looks quite terrible on the page :) 
<img width="832" alt="screen shot 2017-04-04 at 08 45 24" src="https://cloud.githubusercontent.com/assets/3993/24646252/2afbf042-1913-11e7-82b4-dab5d5651f35.png">