### PR TITLE
Build erroneously adding files to ancillary page directories

### DIFF
--- a/index/generate.js
+++ b/index/generate.js
@@ -222,11 +222,11 @@ Metalsmith(__dirname)
   .use(godiApiDataToFiles()) // Set api stored on metadata, retrieved using metalsmith-request above, to files.
   .use(godiGetData({domain: domain, year: year})) // Populate metadata with data from Survey
   .use(jsonToFiles({use_metadata: true}))
-  .use(paths({property: 'paths', directoryIndex: 'index.html'}))
   .use(godiIndexSettings({domain: domain})) // Add data from Index settings.
+  .use(paths({property: 'paths', directoryIndex: 'index.html'}))
   .use(godiDataFiles({domain: domain, year: year})) // Add file metadata to each entry file populated by json-to-files
   .use(markdown())
-  .use(permalinks())
+  .use(permalinks({relative: false}))
   .use(layouts({
     engine: 'nunjucks',
     rename: true,

--- a/index/metalsmith-godi-apidatatofiles.js
+++ b/index/metalsmith-godi-apidatatofiles.js
@@ -70,10 +70,10 @@ function plugin(options) {
         downloadZip.file(`${fileName}.csv`, csvContents);
 
         files[`${baseDir}/${fileName}.json`] = {
-          contents: contents
+          contents: new Buffer(contents)
         };
         files[`${baseDir}/${fileName}.csv`] = {
-          contents: csvContents
+          contents: new Buffer(csvContents)
         };
       }
     });

--- a/index/metalsmith-godi-indexsettings.js
+++ b/index/metalsmith-godi-indexsettings.js
@@ -39,7 +39,7 @@ function plugin(options) {
             title: _.capitalize(keyName),
             layout: 'page.html',
             breadcrumbTitle: _.capitalize(keyName),
-            contents: v
+            contents: new Buffer(v)
           };
           files[keyName + '.md'] = fileData;
           metadata.ancillary_pages.push(keyName);


### PR DESCRIPTION
For some reason, `api` and `download` directories are being built in each ancillary page directory. Sometime up with the build process here.

The impact is minimal, but we're building and uploading more than we need to.