### PR TITLE
Add Help menu to top nav

### DIFF
--- a/census/views/base.html
+++ b/census/views/base.html
@@ -80,6 +80,13 @@
               {% if 'about' in ancillary_pages %}
                 <li><a href="/about/">{{ gettext("About") }}</a></li>
               {% endif %}
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ gettext("Help") }} <span class="caret"></span></a>
+                <ul class="dropdown-menu">
+                  <li><a href="/interpretation/">{{ gettext("How to read results") }}</a></li>
+                  <li><a href="/faq/">{{ gettext("FAQ") }}</a></li>
+                </ul>
+              </li>
             {% endif %}
             {% if not is_index %}
               <li><a href="/about/">{{ gettext("About") }}</a></li>

--- a/census/views/base.html
+++ b/census/views/base.html
@@ -80,9 +80,6 @@
               {% if 'about' in ancillary_pages %}
                 <li><a href="/about/">{{ gettext("About") }}</a></li>
               {% endif %}
-              {% if 'press' in ancillary_pages %}
-                <li><a href="/press/">{{ gettext("Press") }}</a></li>
-              {% endif %}
             {% endif %}
             {% if not is_index %}
               <li><a href="/about/">{{ gettext("About") }}</a></li>


### PR DESCRIPTION
Includes links to:

- FAQ
- How to read results - this is in the spreadsheet CMS under the key `interpretation_page` and uses `interpretation` as the page slug.

Closes #1049 