### PR TITLE
Add container: 'body' to popover options

### DIFF
--- a/census/static/scripts/site/table.js
+++ b/census/static/scripts/site/table.js
@@ -137,7 +137,8 @@ define(['jquery', 'bootstrap', 'chroma', 'tablesorter', 'stickykit'],
           'placement': 'bottom',
           'html': true,
           'show': true,
-          'template': popover_tmpl
+          'template': popover_tmpl,
+          'container': 'body'
       });
 
       $('[data-toggle="popover"]').on('click', function() {


### PR DESCRIPTION
This prevents the popover being clipped when contained from a `overflow: hidden` parent element. Fixes #1056.