### PR TITLE
Fix place.slug formatting for links to previous Index

### DIFF
--- a/census/views/entry.html
+++ b/census/views/entry.html
@@ -41,9 +41,9 @@
           <div class="history">
             <h6>{{ gettext("See other years") }}</h6>
             <ul>
-              <li><a href="http://2015.index.okfn.org/place/{{ place.slug }}/{{ dataset.id }}/2013/" title="2013">2013</a></li>
-              <li><a href="http://2015.index.okfn.org/place/{{ place.slug }}/{{ dataset.id }}/2014/" title="2014">2014</a></li>
-              <li><a href="http://2015.index.okfn.org/place/{{ place.slug }}/{{ dataset.id }}" title="2015">2015</a></li>
+              <li><a href="http://2015.index.okfn.org/place/{{ place.slug | lower | replace('_', '-') }}/{{ dataset.id }}/2013/" title="2013">2013</a></li>
+              <li><a href="http://2015.index.okfn.org/place/{{ place.slug | lower | replace('_', '-') }}/{{ dataset.id }}/2014/" title="2014">2014</a></li>
+              <li><a href="http://2015.index.okfn.org/place/{{ place.slug | lower | replace('_', '-') }}/{{ dataset.id }}" title="2015">2015</a></li>
             </ul>
             <p><small>Note: The methodology used in the Global Open Data Index has changed over time; significantly so between 2015 and 2016. For this reason, the results are not directly comparable over time.</small></p>
           </div>

--- a/census/views/place.html
+++ b/census/views/place.html
@@ -63,9 +63,9 @@
       <div class="history">
         <h6>{{ gettext("See other years") }}</h6>
         <ul>
-          <li><a href="http://2015.index.okfn.org/place/{{ place.slug }}/2013/" title="2013">2013</a></li>
-          <li><a href="http://2015.index.okfn.org/place/{{ place.slug }}/2014/" title="2014">2014</a></li>
-          <li><a href="http://2015.index.okfn.org/place/{{ place.slug }}/" title="2015">2015</a></li>
+          <li><a href="http://2015.index.okfn.org/place/{{ place.slug | lower | replace('_', '-') }}/2013/" title="2013">2013</a></li>
+          <li><a href="http://2015.index.okfn.org/place/{{ place.slug | lower | replace('_', '-') }}/2014/" title="2014">2014</a></li>
+          <li><a href="http://2015.index.okfn.org/place/{{ place.slug | lower | replace('_', '-') }}/" title="2015">2015</a></li>
         </ul>
         <p>
           <small>Note: The methodology used in the Global Open Data Index has changed over time; significantly so between 2015 and 2016. For this reason, the results are not directly comparable over time.</small>


### PR DESCRIPTION
Should be lowercase, and underscores replaced by hyphens.

Fixes #1085.