### PR TITLE
[WIP] Disable sexytables

### DIFF
--- a/census/static/scripts/site/ui.js
+++ b/census/static/scripts/site/ui.js
@@ -12,7 +12,7 @@ define(['jquery', 'bootstrap', 'sexyTables'], function($, bootstrap, sexy) {
         });
 
         $(document).ready(function() {
-            sexyTables();
+          sexyTables();
         })
     }
 


### PR DESCRIPTION
- fixes https://trello.com/c/AJ9neUZB/339-open-data-survey-implement-horizontal-scroll-functionality-for-small-browser-windows

---

@smth 
@dannylammerhirt 
I have tried different `sexyTable()` call options (like document.ready, window.load etc) but it doesn't help. My understanding that there is a bug in the `sexytables` lib (http://www.heldercervantes.com/sexytables/) and because this lib is not maintained we can't really do something about it.

I see these options:
- mark it as know bug and leave as it is (still resizing is not so usual action)
- disable `sexytable`. It will disable sticky table headers - it doesn't seem a good idea
- allocate more time to solve this by switching on different plugin/solution instead of `sexytables`